### PR TITLE
Get aspect ratio reported based on screen size, instead of inches

### DIFF
--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -64,3 +64,19 @@ extension Screen {
         }
     }
 }
+
+// MARK: - Detecting Screen aspect ratio
+
+extension Screen {
+    
+    public var aspectRatio: String? {
+        switch (height, scale) {
+        case (480, _): return "3:2"
+        case (568, _), (667, 3.0), (736, _), (667, 1.0), (667, 2.0): return "16:9"
+        case (812, 3.0): return "19.5:9"
+        case (1024, _), (1112, _), (1366, _): return "4:3"
+        default: return nil
+        }
+    }
+    
+}


### PR DESCRIPTION
iPhones with 3.5 inches will report "3:2"
iPhones with 4 inches, 4.7 inches, 5.5 inches will report "16:9"
iPhone X will report "19.5:9"
iPads will report "4:3"

What do you think? Good feature? Or redundant feature?