### PR TITLE
10.2 inch iPads and iPhone 11(s) notch

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -222,6 +222,9 @@ extension DeviceModel {
 
         case .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR:
             return true
+        case .iPhone11, .iPhone11Pro, .iPhone11ProMax:
+            return true
+            
         default:
           return false
         }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -140,7 +140,7 @@ extension DeviceModel {
         case (6, 7), (6, 8):                  return .iPadPro12_9Inch
         case (7, 1), (7, 2):                  return .iPadPro12_9Inch_SecondGen
         case (8, 5), (8, 6), (8, 7), (8, 8):  return .iPadPro12_9Inch_ThirdGen
-     // case (,):                             return .iPadSevenGen
+        case (7, 11), (7, 12):                return .iPadSevenGen
         default:                              return .unknown
         }
     }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -265,6 +265,10 @@ extension Identifier: CustomStringConvertible {
             return "6th Gen iPad (WiFi)"
         case (7, 6):
             return "6th Gen iPad (Cellular)"
+        case (7 ,11):
+            return "7th Gen iPad (10.2 inch, WiFi)"
+        case (7, 12):
+            return "7th Gen iPad (10.2 inch, Cellular)"
         case (8, 1):
             return "iPad Pro (11 inch, Wi-Fi)"
         case (8, 2):

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -61,8 +61,9 @@ extension Screen {
     func ipadSize1024() -> Double {
         let deviceModel = UIDevice().dc.deviceModel
         switch deviceModel {
-        case .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4: return 7.9
+        case .iPadMini, .iPadMini2, .iPadMini3, .iPadMini4, .iPadMini5: return 7.9
         case .iPadPro10_5Inch: return 10.5
+        case .iPadSevenGen: return 10.2
         default: return 9.7
         }
     }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -192,6 +192,12 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel1 == .iPadSixthGen && deviceModel2 == .iPadSixthGen , "DeviceModel - .iPadSixthGen is failing")
     }
     
+    func testDeviceModelIPadSevenGen() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad7,11"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad7,12"))
+        XCTAssert(deviceModel1 == .iPadSevenGen && deviceModel2 == .iPadSevenGen , "DeviceModel - .iPadSevenGen is failing")
+    }
+    
     func testDeviceModelIPadAir() {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad4,1"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad4,2"))

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -329,7 +329,7 @@ class DeviceModelTests: XCTestCase {
 
     // MARK: Notch test
     func testHasNotch() {
-      let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR]
+      let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax]
 
       let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -316,6 +316,14 @@ class IdentifierTests: XCTestCase {
         XCTAssert(Identifier("iPad8,1").description == "iPad Pro (11 inch, Wi-Fi)", "iPad8,1 is failing to produce a common device model string")
     }
     
+    func testDisplayStringiPad7v12() {
+        XCTAssert(Identifier("iPad7,12").description == "7th Gen iPad (10.2 inch, Cellular)", "iPad7,12 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad7v11() {
+        XCTAssert(Identifier("iPad7,11").description == "7th Gen iPad (10.2 inch, WiFi)", "iPad7,11 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPad7v6() {
         XCTAssert(Identifier("iPad7,6").description == "6th Gen iPad (Cellular)", "iPad7,6 is failing to produce a common device model string")
     }

--- a/UIDeviceComplete.podspec
+++ b/UIDeviceComplete.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'UIDeviceComplete'
-  s.version          = '2.6.0'
+  s.version          = '2.6.5'
   s.summary          = 'UIDevice extensions for device Model, Family, Screen size and more'
  
   s.description      = <<-DESC


### PR DESCRIPTION
- New iPad 10.2 inch support
- iPhone 11, Pro, Pro Max notch support

Got to admit that I've forgotten about the notches, hence its here.