### PR TITLE
Make simulator detection appear as an actual device

### DIFF
--- a/Sources/DeviceFamily.swift
+++ b/Sources/DeviceFamily.swift
@@ -26,7 +26,6 @@ public enum DeviceFamily: String {
     case iPhone
     case iPod
     case iPad
-    //case simulator
     case unknown
 
     public init(rawValue: String) {
@@ -37,8 +36,6 @@ public enum DeviceFamily: String {
             self = .iPod
         case "iPad":
             self = .iPad
-        /*case "x86_64", "i386":
-            self = .simulator*/
         default:
             self = .unknown
         }

--- a/Sources/DeviceFamily.swift
+++ b/Sources/DeviceFamily.swift
@@ -41,3 +41,15 @@ public enum DeviceFamily: String {
         }
     }
 }
+
+// MARK: Simulator Detection
+
+extension DeviceFamily {
+    public var isSimulator: Bool {
+        #if arch(i386) || arch(x86_64)
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Sources/DeviceFamily.swift
+++ b/Sources/DeviceFamily.swift
@@ -26,7 +26,7 @@ public enum DeviceFamily: String {
     case iPhone
     case iPod
     case iPad
-    case simulator
+    //case simulator
     case unknown
 
     public init(rawValue: String) {
@@ -37,8 +37,8 @@ public enum DeviceFamily: String {
             self = .iPod
         case "iPad":
             self = .iPad
-        case "x86_64", "i386":
-            self = .simulator
+        /*case "x86_64", "i386":
+            self = .simulator*/
         default:
             self = .unknown
         }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -192,9 +192,9 @@ extension DeviceModel {
         case "iPhone 8":                return .iPhone8
         case "iPhone 8 Plus":           return .iPhone8Plus
         case "iPhone X":                return .iPhoneX
-        case "iPhone XS":               return .iPhoneXS
-        case "iPhone XS Max":           return .iPhoneXSMax
-        case "iPhone XR":               return .iPhoneXR
+        case "iPhone Xs":               return .iPhoneXS
+        case "iPhone Xs Max":           return .iPhoneXSMax
+        case "iPhone Xʀ":               return .iPhoneXR
         case "iPhone 11":               return .iPhone11
         case "iPhone 11 Pro":           return .iPhone11Pro
         case "iPhone 11 Pro Max":       return .iPhone11ProMax

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -174,43 +174,10 @@ extension DeviceModel {
 
 extension DeviceModel {
     fileprivate static func detectSimulatorModel() -> DeviceModel {
-        guard let versionInfo = ProcessInfo.processInfo.environment["SIMULATOR_VERSION_INFO"],
-            let startIdx = versionInfo.range(of: "DeviceType: ")?.upperBound else {
-                return .unknown
+        guard let simulatorID = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] else {
+            return .unknown
         }
-        let deviceType = versionInfo[startIdx..<versionInfo.endIndex]
-        switch deviceType {
-        case "iPhone 4s":               return .iPhone4S
-        case "iPhone 5s":               return .iPhone5S
-        case "iPhone 6":                return .iPhone6
-        case "iPhone 6 Plus":           return .iPhone6Plus
-        case "iPhone 6s":               return .iPhone6S
-        case "iPhone 6s Plus":          return .iPhone6SPlus
-        case "iPhone SE":               return .iPhoneSE
-        case "iPhone 7":                return .iPhone7
-        case "iPhone 7 Plus":           return .iPhone7Plus
-        case "iPhone 8":                return .iPhone8
-        case "iPhone 8 Plus":           return .iPhone8Plus
-        case "iPhone X":                return .iPhoneX
-        case "iPhone Xs":               return .iPhoneXS
-        case "iPhone Xs Max":           return .iPhoneXSMax
-        case "iPhone Xʀ":               return .iPhoneXR
-        case "iPhone 11":               return .iPhone11
-        case "iPhone 11 Pro":           return .iPhone11Pro
-        case "iPhone 11 Pro Max":       return .iPhone11ProMax
-        case "iPad (5th generation)":   return .iPadFifthGen
-        case "iPad (6th generation)":   return .iPadSixthGen
-        case "iPad Air":                return .iPadAir
-        case "iPad Air 2":              return .iPadAir2
-        case "iPad Air 3":              return .iPadAir3
-        case "iPad Pro (9.7-inch)":     return .iPadPro9_7Inch
-        case "iPad Pro (10.5-inch)":    return .iPadPro10_5Inch
-        case "iPad Pro (11-inch)":      return .iPadPro11Inch
-        case "iPad Pro (12.9-inch)":    return .iPadPro12_9Inch
-        case "iPad Pro (12.9-inch) (2nd generation)":   return .iPadPro12_9Inch_SecondGen
-        case "iPad Pro (12.9-inch) (3rd generation)":   return .iPadPro12_9Inch_ThirdGen
-        default:                        return .unknown
-        }
+        return DeviceModel(identifier: Identifier(simulatorID))
     }
 }
 

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -64,8 +64,8 @@ extension DeviceModel {
             self = DeviceModel.detectIpadModel(with: identifier)
         case .iPod:
             self = DeviceModel.detectIpodModel(with: identifier)
-        case .simulator:
-            self = DeviceModel.detectSimulatorModel()
+        /*case .simulator:
+            self = DeviceModel.detectSimulatorModel()*/
         default:
             self = .unknown
         }
@@ -171,7 +171,7 @@ extension DeviceModel {
 
 
 // MARK: Detecting Simulator Models
-
+/*
 extension DeviceModel {
     fileprivate static func detectSimulatorModel() -> DeviceModel {
         guard let simulatorID = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] else {
@@ -180,7 +180,7 @@ extension DeviceModel {
         return DeviceModel(identifier: Identifier(simulatorID))
     }
 }
-
+*/
 // MARK: Detecting the Notch
 
 extension DeviceModel {

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -64,8 +64,6 @@ extension DeviceModel {
             self = DeviceModel.detectIpadModel(with: identifier)
         case .iPod:
             self = DeviceModel.detectIpodModel(with: identifier)
-        /*case .simulator:
-            self = DeviceModel.detectSimulatorModel()*/
         default:
             self = .unknown
         }
@@ -170,17 +168,6 @@ extension DeviceModel {
 }
 
 
-// MARK: Detecting Simulator Models
-/*
-extension DeviceModel {
-    fileprivate static func detectSimulatorModel() -> DeviceModel {
-        guard let simulatorID = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] else {
-            return .unknown
-        }
-        return DeviceModel(identifier: Identifier(simulatorID))
-    }
-}
-*/
 // MARK: Detecting the Notch
 
 extension DeviceModel {

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -37,11 +37,11 @@ struct Identifier {
 
 extension Identifier {
     static func typeVersionComponents(with identifierString: String) -> (type: String, major: Int?, minor: Int?) {
-        
+        /*
         // Simulator Check
         if identifierString == "x86_64" || identifierString == "i386" {
             return (identifierString, nil, nil)
-        }
+        }*/
         
         let numericCharacters: [String] = (0...9).map { "\($0)" }
         let type = identifierString.prefix(while: { !numericCharacters.contains(String($0))})
@@ -74,8 +74,8 @@ extension Identifier: CustomStringConvertible {
             return iPadStringRepresentation(major: major, minor: minor)
         case .iPod:
             return iPodStringRepresentation(major: major, minor: minor)
-        case .simulator:
-            return "Simulator"
+        /*case .simulator:
+            return "Simulator"*/
         case .unknown:
             return "unknown"
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -37,11 +37,6 @@ struct Identifier {
 
 extension Identifier {
     static func typeVersionComponents(with identifierString: String) -> (type: String, major: Int?, minor: Int?) {
-        /*
-        // Simulator Check
-        if identifierString == "x86_64" || identifierString == "i386" {
-            return (identifierString, nil, nil)
-        }*/
         
         let numericCharacters: [String] = (0...9).map { "\($0)" }
         let type = identifierString.prefix(while: { !numericCharacters.contains(String($0))})
@@ -74,8 +69,6 @@ extension Identifier: CustomStringConvertible {
             return iPadStringRepresentation(major: major, minor: minor)
         case .iPod:
             return iPodStringRepresentation(major: major, minor: minor)
-        /*case .simulator:
-            return "Simulator"*/
         case .unknown:
             return "unknown"
         }

--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -31,8 +31,17 @@ class System {
         // and the rest of the string being zeroed out.
         let encoding: UInt = String.Encoding.ascii.rawValue
         if let string = NSString(bytes: &systemInfo.machine, length: Int(_SYS_NAMELEN), encoding: encoding) {
-            return (string as String).components(separatedBy: "\0").first
+            let identifier = (string as String).components(separatedBy: "\0").first
+            
+            // Simulator Check
+            if identifier == "x86_64" || identifier == "i386" {
+                return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
+            }
+            
+            return identifier
         }
+        
+        
         return nil
     }
 }

--- a/Sources/UIDeviceExtensions.swift
+++ b/Sources/UIDeviceExtensions.swift
@@ -62,9 +62,9 @@ public extension UIDeviceComplete where Base == UIDevice {
     }
 
     /// Simulator
-    var isSimulator: Bool {
+    /*var isSimulator: Bool {
         return deviceFamily == .simulator
-    }
+    }*/
 }
 
 

--- a/Sources/UIDeviceExtensions.swift
+++ b/Sources/UIDeviceExtensions.swift
@@ -61,10 +61,6 @@ public extension UIDeviceComplete where Base == UIDevice {
         return deviceFamily == .iPod
     }
 
-    /// Simulator
-    /*var isSimulator: Bool {
-        return deviceFamily == .simulator
-    }*/
 }
 
 

--- a/Tests/DeviceFamilyTests.swift
+++ b/Tests/DeviceFamilyTests.swift
@@ -40,5 +40,14 @@ class DeviceFamilyTests: XCTestCase {
         let deviceFamily = DeviceFamily(rawValue: "iPad")
         XCTAssert(deviceFamily == .iPad, "DeviceFamily - .iPad is failing")
     }
+    
+    func testDeviceIsSimulator() {
+        let deviceFamily = DeviceFamily(rawValue: "iPhone")
+        #if arch(i386) || arch(x86_64)
+        XCTAssert(deviceFamily.isSimulator, "DeviceFamily - .isSimulator is failing")
+        #else
+        XCTAssert(!(deviceFamily.isSimulator), "DeviceFamily - .isSimulator is failing")
+        #endif
+    }
 
 }

--- a/Tests/DeviceFamilyTests.swift
+++ b/Tests/DeviceFamilyTests.swift
@@ -41,8 +41,4 @@ class DeviceFamilyTests: XCTestCase {
         XCTAssert(deviceFamily == .iPad, "DeviceFamily - .iPad is failing")
     }
 
-    func testDeviceFamilySimulator() {
-        let deviceFamily = DeviceFamily(rawValue: "x86_64")
-        XCTAssert(deviceFamily == .simulator, "DeviceFamily - .simulator is failing")
-    }
 }

--- a/Tests/DeviceFamilyTests.swift
+++ b/Tests/DeviceFamilyTests.swift
@@ -41,6 +41,11 @@ class DeviceFamilyTests: XCTestCase {
         XCTAssert(deviceFamily == .iPad, "DeviceFamily - .iPad is failing")
     }
     
+    func testInvalidDeviceFamily() {
+        let deviceFamily = DeviceFamily(rawValue: "Apple II")
+        XCTAssert(deviceFamily == .unknown, "DeviceFamily - .unknown is failing")
+    }
+    
     func testDeviceIsSimulator() {
         let deviceFamily = DeviceFamily(rawValue: "iPhone")
         #if arch(i386) || arch(x86_64)

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -325,6 +325,13 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPodTouchSeventhGen , "DeviceModel - .iPodSeventhGen is failing")
     }
     
+    // MARK: Unknown Device Test
+    
+    func testInvalidDeviceModel() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone0,1"))
+        XCTAssert(deviceModel == .unknown, "DeviceModel - .unknown is failing")
+    }
+    
     // MARK: Notch test
     func testHasNotch() {
       let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax]

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -325,14 +325,6 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPodTouchSeventhGen , "DeviceModel - .iPodSeventhGen is failing")
     }
     
-    // MARK: Simulator Test
-    
-    func testDeviceModelSimulator() {
-        let deviceModel = DeviceModel(identifier: Identifier("unknown"))
-        
-        XCTAssert(deviceModel == .unknown , "DeviceModel - .unknown is failing")
-    }
-
     // MARK: Notch test
     func testHasNotch() {
       let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax]

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -62,30 +62,6 @@ class IdentifierTests: XCTestCase {
             "Identifier initilization is failing"
         )
     }
-    
-    func testIdentifierInitSimulatorx86() {
-        let testString = "x86_64"
-        let identifier = Identifier(testString)
-        
-        XCTAssert(
-            (identifier.type == .simulator) &&
-                (identifier.version.major == nil) &&
-                (identifier.version.minor == nil),
-            "Identifier initilization is failing"
-        )
-    }
-    
-    func testIdentifierInitSimulatori386() {
-        let testString = "i386"
-        let identifier = Identifier(testString)
-        
-        XCTAssert(
-            (identifier.type == .simulator) &&
-                (identifier.version.major == nil) &&
-                (identifier.version.minor == nil),
-            "Identifier initilization is failing"
-        )
-    }
 
 
     // MARK: - iPhone String Description tests

--- a/Tests/UIDeviceExtensionsTests.swift
+++ b/Tests/UIDeviceExtensionsTests.swift
@@ -51,8 +51,4 @@ class UIDeviceExtensionsTests: XCTestCase {
         XCTAssert(deviceFamily == .iPod, "DeviceExtensions - .isIpod is failing")
     }
     
-    func testDeviceExtensionsIsSimulator() {
-        let deviceFamily = DeviceFamily(rawValue: "x86_64")
-        XCTAssert(deviceFamily == .simulator, "DeviceExtensions - .isSimulator is failing")
-    }
 }


### PR DESCRIPTION
Currently, simulator detection may fail as seen in #41, and is tedious to keep up with new devices.

This implementation ` ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]` directly gives an identifier based on simulator type, which would enable detection to appear like an actual device.