### PR TITLE
Fix for Xcode 12.0 beta 2

### DIFF
--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -43,7 +43,7 @@ extension Identifier {
 
         let version = identifierString.suffix(from: type.endIndex)
             .split(separator: ",")
-            .map { Int(String($0)) }
+            .map { Int($0) }
 
         let major: Int? = !version.isEmpty ? version[0] : nil
         let minor: Int? = version.count > 1 ? version[1] : nil

--- a/UIDeviceComplete.podspec
+++ b/UIDeviceComplete.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'UIDeviceComplete'
-  s.version          = '2.7.2'
+  s.version          = '2.7.3'
   s.summary          = 'UIDevice extensions for device Model, Family, Screen size and more'
  
   s.description      = <<-DESC


### PR DESCRIPTION
Hi, I tried to build the library but i get the error below:

> [x] Undefined symbols for architecture armv7
> Symbol: type metadata for Swift._StringObject.Variant
> Referenced from: outlined init with take of Swift._StringObject.Variant in Identifier.o
> [x] ld: symbol(s) not found for architecture armv7
> [x] clang: error: linker command failed with exit code 1 (use -v to see invocation)

and this pull request is fixing it.