### PR TITLE
Add iPad Air 4, iPad 8

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -36,9 +36,9 @@ public enum DeviceModel: CaseIterable {
     case iPhone11
     case iPhone11Pro, iPhone11ProMax
 
-    case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSevenGen
+    case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen
 
-    case iPadAir, iPadAir2, iPadAir3
+    case iPadAir, iPadAir2, iPadAir3, iPadAir4
 
     case iPadMini, iPadMini2, iPadMini3, iPadMini4, iPadMini5
 
@@ -127,9 +127,12 @@ extension DeviceModel {
         case (3, 4), (3, 5), (3, 6):          return .iPadFourthGen
         case (6, 11), (6, 12):                return .iPadFifthGen
         case (7, 5), (7, 6):                  return .iPadSixthGen
+        case (7, 11), (7, 12):                return .iPadSeventhGen
+        case (11, 6), (11, 7):                return .iPadEighthGen
         case (4, 1), (4, 2), (4, 3):          return .iPadAir
         case (5, 3), (5, 4):                  return .iPadAir2
         case (11, 3), (11, 4):                return .iPadAir3
+        case (13, 1), (13, 2):                return .iPadAir4
         case (2, 5), (2, 6), (2, 7):          return .iPadMini
         case (4, 4), (4, 5), (4, 6):          return .iPadMini2
         case (4, 7), (4, 8), (4, 9):          return .iPadMini3
@@ -143,7 +146,6 @@ extension DeviceModel {
         case (7, 1), (7, 2):                  return .iPadPro12_9Inch_SecondGen
         case (8, 5), (8, 6), (8, 7), (8, 8):  return .iPadPro12_9Inch_ThirdGen
         case (8, 11), (8, 12):                return .iPadPro12_9Inch_FourthGen
-        case (7, 11), (7, 12):                return .iPadSevenGen
         default:                              return .unknown
         }
     }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -296,6 +296,14 @@ extension Identifier: CustomStringConvertible {
             return "3rd Gen iPad Air (Wi-Fi)"
         case (11, 4):
             return "3rd Gen iPad Air (Wi-Fi+LTE)"
+        case (13, 1):
+            return "4th Gen iPad Air (Wi-Fi)"
+        case (13, 2):
+            return "4th Gen iPad Air (Wi-Fi+LTE)"
+        case (11, 6):
+            return "8th Gen iPad (10.2 inch, WiFi)"
+        case (11, 7):
+            return "8th Gen iPad (10.2 inch, Cellular)"
         default:
             return "unknown"
         }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -55,6 +55,7 @@ extension Screen {
         case (1024, _): return ipadSize1024()
         case (1080, _): return 10.2
         case (1112, _): return 10.5
+        case (1180, _): return 10.9
         case (1194, _): return 11.0
         case (1366, _): return 12.9
         default: return nil

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -200,7 +200,13 @@ class DeviceModelTests: XCTestCase {
     func testDeviceModelIPadSevenGen() {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad7,11"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad7,12"))
-        XCTAssert(deviceModel1 == .iPadSevenGen && deviceModel2 == .iPadSevenGen , "DeviceModel - .iPadSevenGen is failing")
+        XCTAssert(deviceModel1 == .iPadSeventhGen && deviceModel2 == .iPadSeventhGen , "DeviceModel - .iPadSevenGen is failing")
+    }
+    
+    func testDeviceModelIPadEighthGen() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad11,6"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad11,7"))
+        XCTAssert(deviceModel1 == .iPadEighthGen && deviceModel2 == .iPadEighthGen , "DeviceModel - .iPadEighthGen is failing")
     }
     
     func testDeviceModelIPadAir() {
@@ -298,6 +304,12 @@ class DeviceModelTests: XCTestCase {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad11,1"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad11,2"))
         XCTAssert(deviceModel1 == .iPadMini5 && deviceModel2 == .iPadMini5 , "DeviceModel - .iPadMini5 is failing")
+    }
+    
+    func testDeviceModelIPadAir4() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad13,1"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad13,2"))
+        XCTAssert(deviceModel1 == .iPadAir4 && deviceModel2 == .iPadAir4 , "DeviceModel - .iPadAir4 is failing")
     }
     
     func testDeviceModelIPadAir3() {

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -248,6 +248,22 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPad
     
+    func testDisplayStringiPad13v2() {
+        XCTAssert(Identifier("iPad13,2").description == "4th Gen iPad Air (Wi-Fi+LTE)", "iPad13,2 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad13v1() {
+        XCTAssert(Identifier("iPad13,1").description == "4th Gen iPad Air (Wi-Fi)", "iPad13,1 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad11v7() {
+        XCTAssert(Identifier("iPad11,7").description == "8th Gen iPad (10.2 inch, Cellular)", "iPad11,7 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad11v6() {
+        XCTAssert(Identifier("iPad11,6").description == "8th Gen iPad (10.2 inch, WiFi)", "iPad11,6 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPad11v4() {
         XCTAssert(Identifier("iPad11,4").description == "3rd Gen iPad Air (Wi-Fi+LTE)", "iPad11,4 is failing to produce a common device model string")
     }


### PR DESCRIPTION
The iPad 7th Gen's names have been changed from `SevenGen` to `SeventhGen` too. Feel the need to enforce good English.

Found the ids, partially from Xcode 12 GM, and through searching on the web to find the other version (cellular or not)

Closes #54.