### PR TITLE
utsname contains nul-terminated strings.

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -118,7 +118,7 @@ extension DeviceModel {
             
         case (13, 1):           return .iPhone12mini
         case (13, 2):           return .iPhone12
-        case (13, 3):           return .iPhone11Pro
+        case (13, 3):           return .iPhone12Pro
         case (13, 4):           return .iPhone12ProMax
             
         default:                return .unknown

--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -28,13 +28,7 @@ class System {
         var systemInfo = utsname()
         uname(&systemInfo)
 
-        // TODO: Find the source of the extra newlines that are getting appended in the end
-        // the cause of this could just be a larger buffer than nessisary getting allocated
-        // and the rest of the string being zeroed out.
-        let encoding: UInt = String.Encoding.ascii.rawValue
-        if let string = NSString(bytes: &systemInfo.machine, length: Int(_SYS_NAMELEN), encoding: encoding) {
-            let identifier = (string as String).components(separatedBy: "\0").first
-            
+        if let identifier = String(cString: &systemInfo.machine.0, encoding: .ascii) {
             // Simulator Check
             if identifier == "x86_64" || identifier == "i386" {
                 return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -383,7 +383,8 @@ class DeviceModelTests: XCTestCase {
     
     // MARK: Notch test
     func testHasNotch() {
-      let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax]
+      let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax,
+                                        .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini]
 
       let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 


### PR DESCRIPTION
uname() is documented to provide nul-terminated strings in utsname.
Hence we can just treat the member as a cstring and pass to the appropriate String inializer.

Additionally fixed some broken unit tests.