### PR TITLE
Add spring 2021 iPads

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -49,6 +49,8 @@ public enum DeviceModel: CaseIterable {
     case iPadPro11Inch, iPadPro12_9Inch_ThirdGen
     
     case iPadPro11Inch_SecondGen, iPadPro12_9Inch_FourthGen
+    
+    case iPadPro11Inch_ThirdGen, iPadPro12_9Inch_FifthGen
 
     case iPodTouchFirstGen, iPodTouchSecondGen, iPodTouchThirdGen,
          iPodTouchFourthGen, iPodTouchFifthGen, iPodTouchSixthGen, iPodTouchSeventhGen
@@ -158,10 +160,14 @@ extension DeviceModel {
         case (7, 3), (7, 4):                  return .iPadPro10_5Inch
         case (8, 1), (8, 2), (8, 3), (8, 4):  return .iPadPro11Inch
         case (8, 9), (8, 10):                 return .iPadPro11Inch_SecondGen
+        case (13, 4), (13, 5), (13, 6), (13, 7):
+                                              return .iPadPro11Inch_ThirdGen
         case (6, 7), (6, 8):                  return .iPadPro12_9Inch
         case (7, 1), (7, 2):                  return .iPadPro12_9Inch_SecondGen
         case (8, 5), (8, 6), (8, 7), (8, 8):  return .iPadPro12_9Inch_ThirdGen
         case (8, 11), (8, 12):                return .iPadPro12_9Inch_FourthGen
+        case (13, 8), (13, 9), (13, 10), (13, 11):
+                                              return .iPadPro12_9Inch_FifthGen
         default:                              return .unknown
         }
     }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -311,6 +311,22 @@ extension Identifier: CustomStringConvertible {
             return "8th Gen iPad (10.2 inch, WiFi)"
         case (11, 7):
             return "8th Gen iPad (10.2 inch, Cellular)"
+        case (13, 4):
+            return "3rd Gen iPad Pro (11 inch, Wi-Fi)"
+        case (13, 5):
+            return "3rd Gen iPad Pro (11 inch, Wi-Fi, 16GB RAM)"
+        case (13, 6):
+            return "3rd Gen iPad Pro (11 inch, Wi-Fi+5G)"
+        case (13, 7):
+            return "3rd Gen iPad Pro (11 inch, Wi-Fi+5G, 16GB RAM)"
+        case (13, 8):
+            return "5th Gen iPad Pro (12.9 inch, Wi-Fi)"
+        case (13, 9):
+            return "5th Gen iPad Pro (12.9 inch, Wi-Fi, 16GB RAM)"
+        case (13, 10):
+            return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
+        case (13, 11):
+            return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G, 16GB RAM)"
         default:
             return "unknown"
         }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -294,6 +294,17 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel1 == .iPadPro11Inch_SecondGen && deviceModel2 == .iPadPro11Inch_SecondGen, "DeviceModel - .iPadPro11Inch_SecondGen is failing")
     }
     
+    func testDeviceModelIPadPro11Inch_ThirdGen() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad13,4"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad13,5"))
+        let deviceModel3 = DeviceModel(identifier: Identifier("iPad13,6"))
+        let deviceModel4 = DeviceModel(identifier: Identifier("iPad13,7"))
+        XCTAssert(deviceModel1 == .iPadPro11Inch_ThirdGen &&
+                    deviceModel2 == .iPadPro11Inch_ThirdGen &&
+                    deviceModel3 == .iPadPro11Inch_ThirdGen &&
+                    deviceModel4 == .iPadPro11Inch_ThirdGen, "DeviceModel - .iPadPro11Inch_ThirdGen is failing")
+    }
+    
     func testDeviceModelIPadPro12_9Inch() {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad6,7"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad6,8"))
@@ -318,6 +329,16 @@ class DeviceModelTests: XCTestCase {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad8,11"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad8,12"))
         XCTAssert(deviceModel1 == .iPadPro12_9Inch_FourthGen && deviceModel2 == .iPadPro12_9Inch_FourthGen, "DeviceModel - .iPadPro12_9Inch_FourthGen is failing")
+    }
+    func testDeviceModelIPadPro12_9Inch_FifthGen() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad13,8"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad13,9"))
+        let deviceModel3 = DeviceModel(identifier: Identifier("iPad13,10"))
+        let deviceModel4 = DeviceModel(identifier: Identifier("iPad13,11"))
+        XCTAssert(deviceModel1 == .iPadPro12_9Inch_FifthGen &&
+                    deviceModel2 == .iPadPro12_9Inch_FifthGen &&
+                    deviceModel3 == .iPadPro12_9Inch_FifthGen &&
+                    deviceModel4 == .iPadPro12_9Inch_FifthGen, "DeviceModel - .iPadPro12_9Inch_FifthGen is failing")
     }
     
     func testDeviceModelIPadMini5() {

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -264,6 +264,31 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPad
     
+    func testDisplayStringiPad13v11() {
+        XCTAssert(Identifier("iPad13,11").description == "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G, 16GB RAM)", "iPad13,11 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v10() {
+        XCTAssert(Identifier("iPad13,10").description == "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G)", "iPad13,10 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v9() {
+        XCTAssert(Identifier("iPad13,9").description == "5th Gen iPad Pro (12.9 inch, Wi-Fi, 16GB RAM)", "iPad13,9 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v8() {
+        XCTAssert(Identifier("iPad13,8").description == "5th Gen iPad Pro (12.9 inch, Wi-Fi)", "iPad13,8 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v7() {
+        XCTAssert(Identifier("iPad13,7").description == "3rd Gen iPad Pro (11 inch, Wi-Fi+5G, 16GB RAM)", "iPad13,7 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v6() {
+        XCTAssert(Identifier("iPad13,6").description == "3rd Gen iPad Pro (11 inch, Wi-Fi+5G)", "iPad13,6 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v5() {
+        XCTAssert(Identifier("iPad13,5").description == "3rd Gen iPad Pro (11 inch, Wi-Fi, 16GB RAM)", "iPad13,5 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad13v4() {
+        XCTAssert(Identifier("iPad13,4").description == "3rd Gen iPad Pro (11 inch, Wi-Fi)", "iPad13,4 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPad13v2() {
         XCTAssert(Identifier("iPad13,2").description == "4th Gen iPad Air (Wi-Fi+LTE)", "iPad13,2 is failing to produce a common device model string")
     }


### PR DESCRIPTION
Not ready,

iPad 13,4, 13,5, 13,8, 13,9 is WiFi
iPad 13,6, 13,7, 13,10, 13,11 is Cellular

But I think its too early to tell which is (probably) the higher RAM version