### PR TITLE
Added iPhones 13, mini 6, iPad 9

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -37,12 +37,14 @@ public enum DeviceModel: CaseIterable {
     case iPhone11Pro, iPhone11ProMax
     case iPhone12mini, iPhone12
     case iPhone12Pro, iPhone12ProMax
+    case iPhone13mini, iPhone13
+    case iPhone13Pro, iPhone13ProMax
 
-    case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen
+    case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen
 
     case iPadAir, iPadAir2, iPadAir3, iPadAir4
 
-    case iPadMini, iPadMini2, iPadMini3, iPadMini4, iPadMini5
+    case iPadMini, iPadMini2, iPadMini3, iPadMini4, iPadMini5, iPadMini6
 
     case iPadPro9_7Inch, iPadPro10_5Inch, iPadPro12_9Inch, iPadPro12_9Inch_SecondGen
     
@@ -123,6 +125,11 @@ extension DeviceModel {
         case (13, 3):           return .iPhone12Pro
         case (13, 4):           return .iPhone12ProMax
             
+        case (14, 4):           return .iPhone13mini
+        case (14, 5):           return .iPhone13
+        case (14, 2):           return .iPhone13Pro
+        case (14, 3):           return .iPhone13ProMax
+            
         default:                return .unknown
         }
     }
@@ -147,6 +154,7 @@ extension DeviceModel {
         case (7, 5), (7, 6):                  return .iPadSixthGen
         case (7, 11), (7, 12):                return .iPadSeventhGen
         case (11, 6), (11, 7):                return .iPadEighthGen
+        case (12, 1), (12, 2):                return .iPadNinthGen
         case (4, 1), (4, 2), (4, 3):          return .iPadAir
         case (5, 3), (5, 4):                  return .iPadAir2
         case (11, 3), (11, 4):                return .iPadAir3
@@ -156,6 +164,7 @@ extension DeviceModel {
         case (4, 7), (4, 8), (4, 9):          return .iPadMini3
         case (5, 1), (5, 2):                  return .iPadMini4
         case (11, 1), (11, 2):                return .iPadMini5
+        case (14, 1), (14, 2):                return .iPadMini6
         case (6, 3), (6, 4):                  return .iPadPro9_7Inch
         case (7, 3), (7, 4):                  return .iPadPro10_5Inch
         case (8, 1), (8, 2), (8, 3), (8, 4):  return .iPadPro11Inch
@@ -208,6 +217,8 @@ extension DeviceModel {
         case .iPhone11, .iPhone11Pro, .iPhone11ProMax:
             return true
         case .iPhone12mini, .iPhone12, .iPhone12Pro, .iPhone12ProMax:
+            return true
+        case .iPhone13mini, .iPhone13, .iPhone13Pro, .iPhone13ProMax:
             return true
             
         default:

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -158,6 +158,14 @@ extension Identifier: CustomStringConvertible {
             return "iPhone 12 Pro"
         case (13, 4):
             return "iPhone 12 Pro Max"
+        case (14, 2):
+            return "iPhone 13 Pro"
+        case (14, 3):
+            return "iPhone 13 Pro Max"
+        case (14, 4):
+            return "iPhone 13 mini"
+        case (14, 5):
+            return "iPhone 13"
 
         default:
             return "unknown"

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -335,6 +335,14 @@ extension Identifier: CustomStringConvertible {
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
         case (13, 11):
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G, 16GB RAM)"
+        case (12, 1):
+            return "9th Gen iPad (10.2 inch, Wi-Fi)"
+        case (12, 2):
+            return "9th Gen iPad (10.2 inch, Wi-Fi+LTE)"
+        case (14, 1):
+            return "6th Gen iPad mini (8.3 inch, Wi-Fi)"
+        case (14, 2):
+            return "6th Gen iPad mini (8.3 inch, Wi-Fi+5G)"
         default:
             return "unknown"
         }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -55,6 +55,7 @@ extension Screen {
         case (1024, _): return ipadSize1024()
         case (1080, _): return 10.2
         case (1112, _): return 10.5
+        case (1133, _): return 8.3
         case (1180, _): return 10.9
         case (1194, _): return 11.0
         case (1366, _): return 12.9

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -176,6 +176,27 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPhone12ProMax , "DeviceModel - .iPhone12ProMax is failing")
     }
     
+    func testDeviceModelIPhone13Mini() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone14,4"))
+        XCTAssert(deviceModel == .iPhone13mini , "DeviceModel - .iPhone13mini is failing")
+    }
+    
+    func testDeviceModelIPhone13() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone14,5"))
+        XCTAssert(deviceModel == .iPhone13 , "DeviceModel - .iPhone13 is failing")
+    }
+    
+    func testDeviceModelIPhone13Pro() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone14,2"))
+        XCTAssert(deviceModel == .iPhone13Pro , "DeviceModel - .iPhone13Pro is failing")
+    }
+    
+    func testDeviceModelIPhone13ProMax() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone14,3"))
+        XCTAssert(deviceModel == .iPhone13ProMax , "DeviceModel - .iPhone13ProMax is failing")
+    }
+    
+    
     // MARK: - iPad Device Model tests
     
     func testDeviceModelIPadFirstGen() {
@@ -404,8 +425,11 @@ class DeviceModelTests: XCTestCase {
     
     // MARK: Notch test
     func testHasNotch() {
-      let notchModels: [DeviceModel] = [.iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR, .iPhone11, .iPhone11Pro, .iPhone11ProMax,
-                                        .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini]
+      let notchModels: [DeviceModel] = [.iPhoneX,
+                                        .iPhoneXS, .iPhoneXSMax, .iPhoneXR,
+                                        .iPhone11, .iPhone11Pro, .iPhone11ProMax,
+                                        .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini,
+                                        .iPhone13, .iPhone13mini, .iPhone13Pro, .iPhone13ProMax]
 
       let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -250,6 +250,12 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel1 == .iPadEighthGen && deviceModel2 == .iPadEighthGen , "DeviceModel - .iPadEighthGen is failing")
     }
     
+    func testDeviceModelIPadNinthGen() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad12,1"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad12,2"))
+        XCTAssert(deviceModel1 == .iPadNinthGen && deviceModel2 == .iPadNinthGen , "DeviceModel - .iPadNinthGen is failing")
+    }
+    
     func testDeviceModelIPadAir() {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad4,1"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad4,2"))
@@ -366,6 +372,12 @@ class DeviceModelTests: XCTestCase {
         let deviceModel1 = DeviceModel(identifier: Identifier("iPad11,1"))
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad11,2"))
         XCTAssert(deviceModel1 == .iPadMini5 && deviceModel2 == .iPadMini5 , "DeviceModel - .iPadMini5 is failing")
+    }
+    
+    func testDeviceModelIPadMini6() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad14,1"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad14,2"))
+        XCTAssert(deviceModel1 == .iPadMini6 && deviceModel2 == .iPadMini6 , "DeviceModel - .iPadMini6 is failing")
     }
     
     func testDeviceModelIPadAir4() {

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -66,6 +66,22 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPhone String Description tests
     
+    func testDisplayStringiPhone14v5() {
+        XCTAssert(Identifier("iPhone14,5").description == "iPhone 13", "iPhone14,5 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone14v4() {
+        XCTAssert(Identifier("iPhone14,4").description == "iPhone 13 mini", "iPhone14,4 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone14v3() {
+        XCTAssert(Identifier("iPhone14,3").description == "iPhone 13 Pro Max", "iPhone14,3 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone14v2() {
+        XCTAssert(Identifier("iPhone14,2").description == "iPhone 13 Pro", "iPhone14,2 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPhone13v4() {
         XCTAssert(Identifier("iPhone13,4").description == "iPhone 12 Pro Max", "iPhone13,4 is failing to produce a common device model string")
     }

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -280,6 +280,12 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPad
     
+    func testDisplayStringiPad14v2() {
+        XCTAssert(Identifier("iPad14,2").description == "6th Gen iPad mini (8.3 inch, Wi-Fi+5G)", "iPad14,2 is failing to produce a common device model string")
+    }
+    func testDisplayStringiPad14v1() {
+        XCTAssert(Identifier("iPad14,1").description == "6th Gen iPad mini (8.3 inch, Wi-Fi)", "iPad14,1 is failing to produce a common device model string")
+    }
     func testDisplayStringiPad13v11() {
         XCTAssert(Identifier("iPad13,11").description == "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G, 16GB RAM)", "iPad13,11 is failing to produce a common device model string")
     }
@@ -311,6 +317,14 @@ class IdentifierTests: XCTestCase {
     
     func testDisplayStringiPad13v1() {
         XCTAssert(Identifier("iPad13,1").description == "4th Gen iPad Air (Wi-Fi)", "iPad13,1 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad12v2() {
+        XCTAssert(Identifier("iPad12,2").description == "9th Gen iPad (10.2 inch, Wi-Fi+LTE)", "iPad12,2 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad12v1() {
+        XCTAssert(Identifier("iPad12,1").description == "9th Gen iPad (10.2 inch, Wi-Fi)", "iPad12,1 is failing to produce a common device model string")
     }
     
     func testDisplayStringiPad11v7() {

--- a/UIDeviceComplete.xcodeproj/project.pbxproj
+++ b/UIDeviceComplete.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "Nicholas Maccharoli";
 				TargetAttributes = {
 					AAB1EF2A1F13866F003BBCF2 = {

--- a/UIDeviceComplete.xcodeproj/xcshareddata/xcschemes/UIDeviceComplete.xcscheme
+++ b/UIDeviceComplete.xcodeproj/xcshareddata/xcschemes/UIDeviceComplete.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
It's that time of the year again! closes #69 

Note that: I am unable to confirm that the details in 11e0109 are 100% accurate, on which of the 2 models are cellular or not, as its based on the observation that the smaller model number tended to be WiFi. 

Identifier info came from Xcode 13 RC's device_traits.db