### PR TITLE
Fix Xcode 14 System.name crashing on app launch

### DIFF
--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -28,10 +28,11 @@ class System {
         var systemInfo = utsname()
         uname(&systemInfo)
         if let identifier = withUnsafePointer(to: &systemInfo.machine, {
-            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-                ptr in String.init(validatingUTF8: ptr)
+            $0.withMemoryRebound(to: CChar.self, capacity: Int(_SYS_NAMELEN)) {
+                ptr in String(cString: ptr)
             }}) {
-            if identifier == "x86_64" || identifier == "i386" {
+            // Simulator Check
+            if identifier == "x86_64" || identifier == "i386" || identifier == "arm64" {
                 return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
             }
             return identifier

--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -33,7 +33,6 @@ class System {
             }}) {
             if identifier == "x86_64" || identifier == "i386" {
                 return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
-
             }
             return identifier
         }

--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -27,17 +27,16 @@ class System {
     static var name: String? {
         var systemInfo = utsname()
         uname(&systemInfo)
-
-        if let identifier = String(cString: &systemInfo.machine.0, encoding: .ascii) {
-            // Simulator Check
+        if let identifier = withUnsafePointer(to: &systemInfo.machine, {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                ptr in String.init(validatingUTF8: ptr)
+            }}) {
             if identifier == "x86_64" || identifier == "i386" {
                 return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
+
             }
-            
             return identifier
         }
-        
-        
         return nil
     }
 }

--- a/Sources/System.swift
+++ b/Sources/System.swift
@@ -27,16 +27,15 @@ class System {
     static var name: String? {
         var systemInfo = utsname()
         uname(&systemInfo)
-        if let identifier = withUnsafePointer(to: &systemInfo.machine, {
+        let identifier = withUnsafePointer(to: &systemInfo.machine, {
             $0.withMemoryRebound(to: CChar.self, capacity: Int(_SYS_NAMELEN)) {
                 ptr in String(cString: ptr)
-            }}) {
-            // Simulator Check
-            if identifier == "x86_64" || identifier == "i386" || identifier == "arm64" {
-                return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
             }
-            return identifier
+        })
+        // Simulator Check
+        if identifier == "x86_64" || identifier == "i386" || identifier == "arm64" {
+            return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
         }
-        return nil
+        return identifier
     }
 }


### PR DESCRIPTION
In Xcode 14, cStrings need to be null-terminated. I updated this variable to work with null-terminated strings but not add extra spaces at the end.

Closes #78  