### PR TITLE
Support iPhone 15 series of devices.

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -41,6 +41,8 @@ public enum DeviceModel: CaseIterable {
     case iPhone13Pro, iPhone13ProMax
     case iPhone14, iPhone14Plus
     case iPhone14Pro, iPhone14ProMax
+    case iPhone15, iPhone15Plus
+    case iPhone15Pro, iPhone15ProMax
 
     case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen, iPadTenthGen
 
@@ -141,6 +143,12 @@ extension DeviceModel {
             
         case (15, 2):           return .iPhone14Pro
         case (15, 3):           return .iPhone14ProMax
+            
+        case (15, 4):           return .iPhone15
+        case (15, 5):           return .iPhone15Plus
+            
+        case (16, 1):           return .iPhone15Pro
+        case (16, 2):           return .iPhone15ProMax
         
         default:                return .unknown
         }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -246,7 +246,19 @@ extension DeviceModel {
             return true
         case .iPhone13mini, .iPhone13, .iPhone13Pro, .iPhone13ProMax:
             return true
-        case .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax:
+        case .iPhone14, .iPhone14Plus:
+            return true
+            
+        default:
+          return false
+        }
+    }
+    
+    public var hasDynamicIsland: Bool {
+        switch self {
+        case .iPhone14Pro, .iPhone14ProMax:
+            return true
+        case .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax:
             return true
             
         default:

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -179,6 +179,15 @@ extension Identifier: CustomStringConvertible {
         case (15, 3):
             return "iPhone 14 Pro Max"
             
+        case (15, 4):
+            return "iPhone 15"
+        case (15, 5):
+            return "iPhone 15 Plus"
+        case (16, 1):
+            return "iPhone 15 Pro"
+        case (16, 2):
+            return "iPhone 15 Pro Max"
+            
         default:
             return "unknown"
         }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -221,6 +221,25 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPhone14ProMax , "DeviceModel - .iPhone14ProMax is failing")
     }
     
+    func testDeviceModelIPhone15() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone15,4"))
+        XCTAssert(deviceModel == .iPhone15 , "DeviceModel - .iPhone15 is failing")
+    }
+    
+    func testDeviceModelIPhone15Plus() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone15,5"))
+        XCTAssert(deviceModel == .iPhone15Plus , "DeviceModel - .iPhone15Plus is failing")
+    }
+    
+    func testDeviceModelIPhone15Pro() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone16,1"))
+        XCTAssert(deviceModel == .iPhone15Pro , "DeviceModel - .iPhone15Pro is failing")
+    }
+    
+    func testDeviceModelIPhone15ProMax() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone16,2"))
+        XCTAssert(deviceModel == .iPhone15ProMax , "DeviceModel - .iPhone15ProMax is failing")
+    }
     
     // MARK: - iPad Device Model tests
     

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -487,16 +487,16 @@ class DeviceModelTests: XCTestCase {
     
     // MARK: Notch test
     func testHasNotch() {
-      let notchModels: [DeviceModel] = [.iPhoneX,
+        let notchModels: [DeviceModel] = [.iPhoneX,
                                         .iPhoneXS, .iPhoneXSMax, .iPhoneXR,
                                         .iPhone11, .iPhone11Pro, .iPhone11ProMax,
                                         .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini,
                                         .iPhone13, .iPhone13mini, .iPhone13Pro, .iPhone13ProMax,
                                         .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax]
 
-      let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
+        let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 
-      notchModels.forEach { XCTAssertTrue($0.hasNotch) }
-      noNotchModels.forEach { XCTAssertFalse($0.hasNotch) }
+        notchModels.forEach { XCTAssertTrue($0.hasNotch) }
+        noNotchModels.forEach { XCTAssertFalse($0.hasNotch) }
     }
 }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -492,11 +492,23 @@ class DeviceModelTests: XCTestCase {
                                         .iPhone11, .iPhone11Pro, .iPhone11ProMax,
                                         .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini,
                                         .iPhone13, .iPhone13mini, .iPhone13Pro, .iPhone13ProMax,
-                                        .iPhone14, .iPhone14Plus, .iPhone14Pro, .iPhone14ProMax]
+                                        .iPhone14, .iPhone14Plus]
 
         let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 
         notchModels.forEach { XCTAssertTrue($0.hasNotch) }
         noNotchModels.forEach { XCTAssertFalse($0.hasNotch) }
+    }
+    
+    // MARK: Dynamic Island Test
+    
+    func testHasDynamicIsland() {
+        let withModels: [DeviceModel] = [.iPhone14Pro, .iPhone14ProMax,
+                                         .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax]
+
+        let withoutModels: [DeviceModel] = DeviceModel.allCases.filter( { !withModels.contains($0) })
+
+        withModels.forEach { XCTAssertTrue($0.hasDynamicIsland) }
+        withoutModels.forEach { XCTAssertFalse($0.hasDynamicIsland) }
     }
 }

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -66,6 +66,22 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPhone String Description tests
     
+    func testDisplayStringiPhone16v2() {
+        XCTAssert(Identifier("iPhone16,2").description == "iPhone 15 Pro Max", "iPhone16,2 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone16v1() {
+        XCTAssert(Identifier("iPhone16,1").description == "iPhone 15 Pro", "iPhone16,1 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone15v5() {
+        XCTAssert(Identifier("iPhone15,5").description == "iPhone 15 Plus", "iPhone15,5 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone15v4() {
+        XCTAssert(Identifier("iPhone15,4").description == "iPhone 15", "iPhone15,4 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPhone15v3() {
         XCTAssert(Identifier("iPhone15,3").description == "iPhone 14 Pro Max", "iPhone15,3 is failing to produce a common device model string")
     }


### PR DESCRIPTION
It's that **Ti**me of the year again!

Also: Previously, `DeviceModel.hasNotch` will return true for Dynamic Island devices like the iPhone 14 Pro. In this pull request, that will no longer be true, as there's a new `DeviceModel.hasDynamicIsland`, specific for that use case.

Tests have also been updated to reflect the changes of this pull request. 