### PR TITLE
Addition of devices introduced in 2024, minor clean up for iPad content

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -48,6 +48,8 @@ public enum DeviceModel: CaseIterable {
     case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen, iPadTenthGen
 
     case iPadAir, iPadAir2, iPadAir3, iPadAir4, iPadAir5
+    
+    case iPadAir11InchM2, iPadAir13InchM2
 
     case iPadMini, iPadMini2, iPadMini3, iPadMini4, iPadMini5, iPadMini6
 
@@ -60,6 +62,8 @@ public enum DeviceModel: CaseIterable {
     case iPadPro11Inch_ThirdGen, iPadPro12_9Inch_FifthGen
             
     case iPadPro11Inch_FourthGen, iPadPro12_9Inch_SixthGen
+    
+    case iPadPro11InchM4, iPadPro13InchM4
 
     case iPodTouchFirstGen, iPodTouchSecondGen, iPodTouchThirdGen,
          iPodTouchFourthGen, iPodTouchFifthGen, iPodTouchSixthGen, iPodTouchSeventhGen
@@ -205,6 +209,10 @@ extension DeviceModel {
         case (11, 3), (11, 4):                return .iPadAir3
         case (13, 1), (13, 2):                return .iPadAir4
         case (13, 16), (13, 17):              return .iPadAir5
+        case (14, 8), (14, 9):
+                                              return .iPadAir11InchM2
+        case (14, 10), (14, 11):
+                                              return .iPadAir13InchM2
         case (2, 5), (2, 6), (2, 7):          return .iPadMini
         case (4, 4), (4, 5), (4, 6):          return .iPadMini2
         case (4, 7), (4, 8), (4, 9):          return .iPadMini3
@@ -227,6 +235,10 @@ extension DeviceModel {
                                               return .iPadPro12_9Inch_FifthGen
         case (14, 5), (14, 6):
                                               return .iPadPro12_9Inch_SixthGen
+        case (16, 3), (16, 4):
+                                              return .iPadPro11InchM4
+        case (16, 5), (16, 6):
+                                              return .iPadPro13InchM4
         default:                              return .unknown
         }
     }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -85,6 +85,7 @@ public enum DeviceModel: CaseIterable {
     case ultra
     case series9
     case ultra2
+    case series10
     #endif
     
     case unknown
@@ -300,7 +301,7 @@ extension DeviceModel {
         case (6, 18):                               return .ultra
         case (7, 1), (7, 2), (7, 3), (7, 4):        return .series9
         case (7, 5):                                return .ultra2
-            
+        case (7, 8), (7, 9), (7, 10), (7, 11):      return .series10
         default:                                    return .unknown
         }
     }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -44,6 +44,8 @@ public enum DeviceModel: CaseIterable {
     case iPhone14Pro, iPhone14ProMax
     case iPhone15, iPhone15Plus
     case iPhone15Pro, iPhone15ProMax
+    case iPhone16, iPhone16Plus
+    case iPhone16Pro, iPhone16ProMax
 
     case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen, iPadTenthGen
 
@@ -176,6 +178,11 @@ extension DeviceModel {
             
         case (16, 1):           return .iPhone15Pro
         case (16, 2):           return .iPhone15ProMax
+            
+        case (17, 1):           return .iPhone16Pro
+        case (17, 2):           return .iPhone16ProMax
+        case (17, 3):           return .iPhone16
+        case (17, 4):           return .iPhone16Plus
         
         default:                return .unknown
         }
@@ -329,7 +336,8 @@ extension DeviceModel {
             return true
         case .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax:
             return true
-            
+        case .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax:
+            return true
         default:
           return false
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -190,6 +190,16 @@ extension Identifier: CustomStringConvertible {
         case (16, 2):
             return "iPhone 15 Pro Max"
             
+        case (17, 3):
+            return "iPhone 16"
+        case (17, 4):
+            return "iPhone 16 Plus"
+        case (17, 1):
+            return "iPhone 16 Pro"
+        case (17, 2):
+            return "iPhone 16 Pro Max"
+            
+            
         default:
             return "unknown"
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -512,6 +512,14 @@ extension Identifier: CustomStringConvertible {
             return "Apple Watch Series 9, 45mm case (GPS + Cellular)"
         case (7, 5):
             return "Apple Watch Ultra 2"
+        case (7, 8):
+            return "Apple Watch Series 10, 42mm case (GPS)"
+        case (7, 9):
+            return "Apple Watch Series 10, 46mm case (GPS)"
+        case (7, 10):
+            return "Apple Watch Series 10, 42mm case (GPS + Cellular)"
+        case (7, 11):
+            return "Apple Watch Series 10, 46mm case (GPS + Cellular)"
         default:
             return "unknown"
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -355,9 +355,9 @@ extension Identifier: CustomStringConvertible {
         case (13, 7):
             return "3rd Gen iPad Pro (11 inch, Wi-Fi+5G, 16GB RAM)"
         case (14, 3):
-            return "4rd Gen iPad Pro (11 inch, Wi-Fi)"
+            return "4th Gen iPad Pro (11 inch, Wi-Fi)"
         case (14, 4):
-            return "4rd Gen iPad Pro (11 inch, Wi-Fi+5G)"
+            return "4th Gen iPad Pro (11 inch, Wi-Fi+5G)"
         case (13, 8):
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi)"
         case (13, 9):

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -336,12 +336,12 @@ extension Identifier: CustomStringConvertible {
             return "3rd Gen iPad Air (Wi-Fi+LTE)"
         case (13, 1):
             return "4th Gen iPad Air (Wi-Fi)"
+        case (13, 2):
+            return "4th Gen iPad Air (Wi-Fi+LTE)"
         case (13, 16):
             return "5th Gen iPad Air (Wi-Fi)"
         case (13, 17):
             return "5th Gen iPad Air (Wi-Fi+5G)"
-        case (13, 2):
-            return "4th Gen iPad Air (Wi-Fi+LTE)"
         case (11, 6):
             return "8th Gen iPad (10.2 inch, WiFi)"
         case (11, 7):

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -334,18 +334,20 @@ extension Identifier: CustomStringConvertible {
             return "3rd Gen iPad Air (Wi-Fi)"
         case (11, 4):
             return "3rd Gen iPad Air (Wi-Fi+LTE)"
-        case (13, 1):
-            return "4th Gen iPad Air (Wi-Fi)"
-        case (13, 2):
-            return "4th Gen iPad Air (Wi-Fi+LTE)"
-        case (13, 16):
-            return "5th Gen iPad Air (Wi-Fi)"
-        case (13, 17):
-            return "5th Gen iPad Air (Wi-Fi+5G)"
         case (11, 6):
             return "8th Gen iPad (10.2 inch, WiFi)"
         case (11, 7):
             return "8th Gen iPad (10.2 inch, Cellular)"
+        case (12, 1):
+            return "9th Gen iPad (10.2 inch, Wi-Fi)"
+        case (12, 2):
+            return "9th Gen iPad (10.2 inch, Wi-Fi+LTE)"
+            
+        case (13, 1):
+            return "4th Gen iPad Air (Wi-Fi)"
+        case (13, 2):
+            return "4th Gen iPad Air (Wi-Fi+LTE)"
+            
         case (13, 4):
             return "3rd Gen iPad Pro (11 inch, Wi-Fi)"
         case (13, 5):
@@ -354,10 +356,6 @@ extension Identifier: CustomStringConvertible {
             return "3rd Gen iPad Pro (11 inch, Wi-Fi+5G)"
         case (13, 7):
             return "3rd Gen iPad Pro (11 inch, Wi-Fi+5G, 16GB RAM)"
-        case (14, 3):
-            return "4th Gen iPad Pro (11 inch, Wi-Fi)"
-        case (14, 4):
-            return "4th Gen iPad Pro (11 inch, Wi-Fi+5G)"
         case (13, 8):
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi)"
         case (13, 9):
@@ -366,22 +364,31 @@ extension Identifier: CustomStringConvertible {
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
         case (13, 11):
             return "5th Gen iPad Pro (12.9 inch, Wi-Fi+5G, 16GB RAM)"
-        case (14, 5):
-            return "6th Gen iPad Pro (12.9 inch, Wi-Fi)"
-        case (14, 6):
-            return "6th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
-        case (12, 1):
-            return "9th Gen iPad (10.2 inch, Wi-Fi)"
-        case (12, 2):
-            return "9th Gen iPad (10.2 inch, Wi-Fi+LTE)"
+            
+        case (13, 16):
+            return "5th Gen iPad Air (Wi-Fi)"
+        case (13, 17):
+            return "5th Gen iPad Air (Wi-Fi+5G)"
+            
         case (13, 18):
             return "10th Gen iPad (10.9 inch, Wi-Fi)"
         case (13, 19):
             return "10th Gen iPad (10.9 inch, Wi-Fi+5G)"
+            
         case (14, 1):
             return "6th Gen iPad mini (8.3 inch, Wi-Fi)"
         case (14, 2):
             return "6th Gen iPad mini (8.3 inch, Wi-Fi+5G)"
+            
+        case (14, 3):
+            return "4th Gen iPad Pro (11 inch, Wi-Fi)"
+        case (14, 4):
+            return "4th Gen iPad Pro (11 inch, Wi-Fi+5G)"
+        case (14, 5):
+            return "6th Gen iPad Pro (12.9 inch, Wi-Fi)"
+        case (14, 6):
+            return "6th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
+            
         default:
             return "unknown"
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -389,6 +389,24 @@ extension Identifier: CustomStringConvertible {
         case (14, 6):
             return "6th Gen iPad Pro (12.9 inch, Wi-Fi+5G)"
             
+        case (14, 8):
+            return "iPad Air M2 (11 inch, Wi-Fi)"
+        case (14, 9):
+            return "iPad Air M2 (11 inch, Wi-Fi+5G)"
+        case (14, 10):
+            return "iPad Air M2 (13 inch, Wi-Fi)"
+        case (14, 11):
+            return "iPad Air M2 (13 inch, Wi-Fi+5G)"
+            
+        case (16, 3):
+            return "iPad Pro M4 (11 inch, Wi-Fi)"
+        case (16, 4):
+            return "iPad Pro M4 (11 inch, Wi-Fi+5G)"
+        case (16, 5):
+            return "iPad Pro M4 (13 inch, Wi-Fi)"
+        case (16, 6):
+            return "iPad Pro M4 (13 inch, Wi-Fi+5G)"
+            
         default:
             return "unknown"
         }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -106,28 +106,53 @@ extension Screen {
 #if os(watchOS)
 extension Screen {
     public var caseSize: Int? {
+        switch size {
+        case .small(let mm):
+            return mm
+        case .medium(let mm):
+            return mm
+        case .ultra(let mm):
+            return mm
+        default:
+            return nil
+        }
+    }
+    
+    public var size: Size? {
         guard let major = identifier.version.major,
               let minor = identifier.version.minor
         else { return nil }
         
         switch (major, minor) {
-        case (1, 1), (2, 3), (2, 6), (3, 1), (3, 3):        return 38
-        case (1, 2), (2, 4), (2, 7), (3, 2), (3, 4):        return 42
+        case (1, 1), (2, 3), (2, 6), (3, 1), (3, 3):        return .small(mm: 38)
+        case (1, 2), (2, 4), (2, 7), (3, 2), (3, 4):        return .medium(mm: 42)
             
         case (4, 1), (4, 3), (5, 1), (5, 3), (5, 9),
-             (5, 11), (6, 1), (6, 3), (6, 10), (6, 12):     return 40
+             (5, 11), (6, 1), (6, 3), (6, 10), (6, 12):     return .small(mm: 40)
         case (4, 2), (4, 4), (5, 2), (5, 4), (5, 10),
-             (5, 12), (6, 2), (6, 4), (6, 11), (6, 13):     return 44
+             (5, 12), (6, 2), (6, 4), (6, 11), (6, 13):     return .medium(mm: 44)
             
         case (6, 6), (6, 8), (6, 14), (6, 16),
-             (7, 1), (7, 3):                                return 41
+             (7, 1), (7, 3):                                return .small(mm: 41)
         case (6, 7), (6, 9), (6, 15), (6, 17),
-             (7, 2), (7, 4):                                return 45
+             (7, 2), (7, 4):                                return .medium(mm: 45)
             
-        case (6, 18), (7, 5):                               return 49
+        case (6, 18), (7, 5):                               return .ultra(mm: 49)
+            
+        case (7, 8), (7, 10):                               return .small(mm: 42)
+        case (7, 9), (7, 11):                               return .medium(mm: 46)
             
         default:                                            return nil
         }
+    }
+    
+    public enum Size {
+        /// The smaller Apple Watch size (traditionally: 38/40/41mm)
+        case small(mm: Int)
+        /// The larger Apple Watch size (traditionally: 42/44/45mm)
+        case medium(mm: Int)
+        /// Apple Watch Ultra size
+        case ultra(mm: Int)
     }
 }
 #endif

--- a/Sources/UIDeviceExtensions.swift
+++ b/Sources/UIDeviceExtensions.swift
@@ -83,4 +83,11 @@ public extension UIDeviceComplete where Base == DCDevice {
         return Screen(width: width, height: height, scale: scale)
     }
 }
+#elseif os(watchOS)
+public extension UIDeviceComplete where Base == WKInterfaceDevice {
+    var screenSize: Screen? {
+        guard let identifier else { return nil }
+        return Screen(identifier: identifier)
+    }
+}
 #endif

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -647,5 +647,16 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .ultra2, "DeviceModel - .ultra2 is failing")
     }
     
+    func testDeviceModelWatchSeries10() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("Watch7,8"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("Watch7,9"))
+        let deviceModel3 = DeviceModel(identifier: Identifier("Watch7,10"))
+        let deviceModel4 = DeviceModel(identifier: Identifier("Watch7,11"))
+        XCTAssert(deviceModel1 == .series10, "DeviceModel - .series10 is failing")
+        XCTAssert(deviceModel2 == .series10, "DeviceModel - .series10 is failing")
+        XCTAssert(deviceModel3 == .series10, "DeviceModel - .series10 is failing")
+        XCTAssert(deviceModel4 == .series10, "DeviceModel - .series10 is failing")
+    }
+    
     #endif
 }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -402,15 +402,33 @@ class DeviceModelTests: XCTestCase {
         let deviceModel2 = DeviceModel(identifier: Identifier("iPad8,12"))
         XCTAssert(deviceModel1 == .iPadPro12_9Inch_FourthGen && deviceModel2 == .iPadPro12_9Inch_FourthGen, "DeviceModel - .iPadPro12_9Inch_FourthGen is failing")
     }
-    func testDeviceModelIPadPro12_9Inch_FifthGen() {
-        let deviceModel1 = DeviceModel(identifier: Identifier("iPad13,8"))
-        let deviceModel2 = DeviceModel(identifier: Identifier("iPad13,9"))
-        let deviceModel3 = DeviceModel(identifier: Identifier("iPad13,10"))
-        let deviceModel4 = DeviceModel(identifier: Identifier("iPad13,11"))
-        XCTAssert(deviceModel1 == .iPadPro12_9Inch_FifthGen &&
-                    deviceModel2 == .iPadPro12_9Inch_FifthGen &&
-                    deviceModel3 == .iPadPro12_9Inch_FifthGen &&
-                    deviceModel4 == .iPadPro12_9Inch_FifthGen, "DeviceModel - .iPadPro12_9Inch_FifthGen is failing")
+    
+    func testDeviceModelIPadAir11InchM2() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad14,8"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad14,9"))
+        XCTAssert(deviceModel1 == .iPadAir11InchM2 &&
+                    deviceModel2 == .iPadAir11InchM2, "DeviceModel - .iPadAir11InchM2 is failing")
+    }
+    
+    func testDeviceModelIPadAir13InchM2() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad14,10"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad14,11"))
+        XCTAssert(deviceModel1 == .iPadAir13InchM2 &&
+                    deviceModel2 == .iPadAir13InchM2, "DeviceModel - .iPadAir13InchM2 is failing")
+    }
+    
+    func testDeviceModelIPadPro11InchM4() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad16,3"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad16,4"))
+        XCTAssert(deviceModel1 == .iPadPro11InchM4 &&
+                    deviceModel2 == .iPadPro11InchM4, "DeviceModel - .iPadPro11InchM4 is failing")
+    }
+    
+    func testDeviceModelIPadPro13InchM4() {
+        let deviceModel1 = DeviceModel(identifier: Identifier("iPad16,5"))
+        let deviceModel2 = DeviceModel(identifier: Identifier("iPad16,6"))
+        XCTAssert(deviceModel1 == .iPadPro13InchM4 &&
+                    deviceModel2 == .iPadPro13InchM4, "DeviceModel - .iPadPro13InchM4 is failing")
     }
     
     func testDeviceModelIPadMini5() {

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -242,6 +242,26 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPhone15ProMax , "DeviceModel - .iPhone15ProMax is failing")
     }
     
+    func testDeviceModelIPhone16() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone17,3"))
+        XCTAssert(deviceModel == .iPhone16, "DeviceModel - .iPhone16 is failing")
+    }
+    
+    func testDeviceModelIPhone16Plus() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone17,4"))
+        XCTAssert(deviceModel == .iPhone16Plus, "DeviceModel - .iPhone16Plus is failing")
+    }
+    
+    func testDeviceModelIPhone16Pro() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone17,1"))
+        XCTAssert(deviceModel == .iPhone16Pro, "DeviceModel - .iPhone16Pro is failing")
+    }
+    
+    func testDeviceModelIPhone16ProMax() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone17,2"))
+        XCTAssert(deviceModel == .iPhone16ProMax, "DeviceModel - .iPhone16ProMax is failing")
+    }
+    
     // MARK: - iPad Device Model tests
     
     func testDeviceModelIPadFirstGen() {
@@ -523,7 +543,8 @@ class DeviceModelTests: XCTestCase {
     
     func testHasDynamicIsland() {
         let withModels: [DeviceModel] = [.iPhone14Pro, .iPhone14ProMax,
-                                         .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax]
+                                         .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax,
+                                         .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax]
 
         let withoutModels: [DeviceModel] = DeviceModel.allCases.filter( { !withModels.contains($0) })
 

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -332,9 +332,59 @@ class IdentifierTests: XCTestCase {
 
     // MARK: - iPad
     
+    
+    func testDisplayStringiPad16v6() {
+        XCTAssert(Identifier("iPad16,6").description == "iPad Pro M4 (13 inch, Wi-Fi+5G)", "iPad16,6 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad16v5() {
+        XCTAssert(Identifier("iPad16,5").description == "iPad Pro M4 (13 inch, Wi-Fi)", "iPad16,5 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad16v4() {
+        XCTAssert(Identifier("iPad16,4").description == "iPad Pro M4 (11 inch, Wi-Fi+5G)", "iPad16,4 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad16v3() {
+        XCTAssert(Identifier("iPad16,3").description == "iPad Pro M4 (11 inch, Wi-Fi)", "iPad16,3 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v11() {
+        XCTAssert(Identifier("iPad14,11").description == "iPad Air M2 (13 inch, Wi-Fi+5G)", "iPad14,11 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v10() {
+        XCTAssert(Identifier("iPad14,10").description == "iPad Air M2 (13 inch, Wi-Fi)", "iPad14,10 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v9() {
+        XCTAssert(Identifier("iPad14,9").description == "iPad Air M2 (11 inch, Wi-Fi+5G)", "iPad14,9 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v8() {
+        XCTAssert(Identifier("iPad14,8").description == "iPad Air M2 (11 inch, Wi-Fi)", "iPad14,8 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v6() {
+        XCTAssert(Identifier("iPad14,6").description == "6th Gen iPad Pro (12.9 inch, Wi-Fi+5G)", "iPad14,6 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v5() {
+        XCTAssert(Identifier("iPad14,5").description == "6th Gen iPad Pro (12.9 inch, Wi-Fi)", "iPad14,5 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v4() {
+        XCTAssert(Identifier("iPad14,4").description == "4th Gen iPad Pro (11 inch, Wi-Fi+5G)", "iPad14,4 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPad14v3() {
+        XCTAssert(Identifier("iPad14,3").description == "4th Gen iPad Pro (11 inch, Wi-Fi)", "iPad14,3 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPad14v2() {
         XCTAssert(Identifier("iPad14,2").description == "6th Gen iPad mini (8.3 inch, Wi-Fi+5G)", "iPad14,2 is failing to produce a common device model string")
     }
+    
     func testDisplayStringiPad14v1() {
         XCTAssert(Identifier("iPad14,1").description == "6th Gen iPad mini (8.3 inch, Wi-Fi)", "iPad14,1 is failing to produce a common device model string")
     }

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -790,5 +790,21 @@ class IdentifierTests: XCTestCase {
         XCTAssert(Identifier("Watch7,5").description == "Apple Watch Ultra 2", "Watch7,5 is failing to produce a common device model string")
     }
     
+    func testDisplayStringWatch7v8() {
+        XCTAssert(Identifier("Watch7,8").description == "Apple Watch Series 10, 42mm case (GPS)", "Watch7,8 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringWatch7v9() {
+        XCTAssert(Identifier("Watch7,9").description == "Apple Watch Series 10, 46mm case (GPS)", "Watch7,9 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringWatch7v10() {
+        XCTAssert(Identifier("Watch7,10").description == "Apple Watch Series 10, 42mm case (GPS + Cellular)", "Watch7,10 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringWatch7v11() {
+        XCTAssert(Identifier("Watch7,11").description == "Apple Watch Series 10, 46mm case (GPS + Cellular)", "Watch7,11 is failing to produce a common device model string")
+    }
+    
     #endif
 }

--- a/Tests/IdentifierTests.swift
+++ b/Tests/IdentifierTests.swift
@@ -66,6 +66,22 @@ class IdentifierTests: XCTestCase {
     #if os(iOS)
     // MARK: - iPhone String Description tests
     
+    func testDisplayStringiPhone17v4() {
+        XCTAssert(Identifier("iPhone17,4").description == "iPhone 16 Plus", "iPhone17,4 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone17v3() {
+        XCTAssert(Identifier("iPhone17,3").description == "iPhone 16", "iPhone17,3 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone17v2() {
+        XCTAssert(Identifier("iPhone17,2").description == "iPhone 16 Pro Max", "iPhone17,2 is failing to produce a common device model string")
+    }
+    
+    func testDisplayStringiPhone17v1() {
+        XCTAssert(Identifier("iPhone17,1").description == "iPhone 16 Pro", "iPhone17,1 is failing to produce a common device model string")
+    }
+    
     func testDisplayStringiPhone16v2() {
         XCTAssert(Identifier("iPhone16,2").description == "iPhone 15 Pro Max", "iPhone16,2 is failing to produce a common device model string")
     }


### PR DESCRIPTION
As per title.

Checklist:
- [x] iPad Air M2
- [x] iPad Pro M4
- [x] iPhone 16 series
- [x] Apple Watch Series 10
- [x] Update tests
- [x] Update CI

Supersedes #95, #96, #97