### PR TITLE
Add device models launched after October 2024

### DIFF
--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -46,14 +46,18 @@ public enum DeviceModel: CaseIterable {
     case iPhone15Pro, iPhone15ProMax
     case iPhone16, iPhone16Plus
     case iPhone16Pro, iPhone16ProMax
+    case iPhone16e
 
     case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen, iPadTenthGen
+    case iPadA16
 
     case iPadAir, iPadAir2, iPadAir3, iPadAir4, iPadAir5
     
     case iPadAir11InchM2, iPadAir13InchM2
+    case iPadAir11InchM3, iPadAir13InchM3
 
     case iPadMini, iPadMini2, iPadMini3, iPadMini4, iPadMini5, iPadMini6
+    case iPadMiniA17Pro
 
     case iPadPro9_7Inch, iPadPro10_5Inch, iPadPro12_9Inch, iPadPro12_9Inch_SecondGen
     
@@ -184,6 +188,8 @@ extension DeviceModel {
         case (17, 2):           return .iPhone16ProMax
         case (17, 3):           return .iPhone16
         case (17, 4):           return .iPhone16Plus
+            
+        case (17, 5):           return .iPhone16e
         
         default:                return .unknown
         }
@@ -212,21 +218,26 @@ extension DeviceModel {
         case (11, 6), (11, 7):                return .iPadEighthGen
         case (12, 1), (12, 2):                return .iPadNinthGen                
         case (13, 18), (13, 19):              return .iPadTenthGen
+        case (15, 7), (15, 8):                return .iPadA16
+            
         case (4, 1), (4, 2), (4, 3):          return .iPadAir
         case (5, 3), (5, 4):                  return .iPadAir2
         case (11, 3), (11, 4):                return .iPadAir3
         case (13, 1), (13, 2):                return .iPadAir4
         case (13, 16), (13, 17):              return .iPadAir5
-        case (14, 8), (14, 9):
-                                              return .iPadAir11InchM2
-        case (14, 10), (14, 11):
-                                              return .iPadAir13InchM2
+        case (14, 8), (14, 9):                return .iPadAir11InchM2
+        case (14, 10), (14, 11):              return .iPadAir13InchM2
+        case (15, 3), (15, 4):                return .iPadAir11InchM3
+        case (15, 5), (15, 6):                return .iPadAir13InchM3
+            
         case (2, 5), (2, 6), (2, 7):          return .iPadMini
         case (4, 4), (4, 5), (4, 6):          return .iPadMini2
         case (4, 7), (4, 8), (4, 9):          return .iPadMini3
         case (5, 1), (5, 2):                  return .iPadMini4
         case (11, 1), (11, 2):                return .iPadMini5
         case (14, 1), (14, 2):                return .iPadMini6
+        case (16, 1), (16, 2):                return .iPadMiniA17Pro
+            
         case (6, 3), (6, 4):                  return .iPadPro9_7Inch
         case (7, 3), (7, 4):                  return .iPadPro10_5Inch
         case (8, 1), (8, 2), (8, 3), (8, 4):  return .iPadPro11Inch
@@ -314,7 +325,6 @@ extension DeviceModel {
 extension DeviceModel {
     public var hasNotch: Bool {
         switch self {
-
         case .iPhoneX, .iPhoneXS, .iPhoneXSMax, .iPhoneXR:
             return true
         case .iPhone11, .iPhone11Pro, .iPhone11ProMax:
@@ -325,7 +335,8 @@ extension DeviceModel {
             return true
         case .iPhone14, .iPhone14Plus:
             return true
-            
+        case .iPhone16e:
+            return true
         default:
           return false
         }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -90,6 +90,9 @@ public enum DeviceModel: CaseIterable {
     case series9
     case ultra2
     case series10
+    case series11
+    case ultra3
+    case se3
     #endif
     
     case unknown
@@ -313,6 +316,9 @@ extension DeviceModel {
         case (7, 1), (7, 2), (7, 3), (7, 4):        return .series9
         case (7, 5):                                return .ultra2
         case (7, 8), (7, 9), (7, 10), (7, 11):      return .series10
+        case (7, 17), (7, 18), (7, 19), (7, 20):    return .series11
+        case (7, 12):                               return .ultra3
+        case (7, 13), (7, 14), (7, 15), (7, 16):    return .se3
         default:                                    return .unknown
         }
     }

--- a/Sources/DeviceModel.swift
+++ b/Sources/DeviceModel.swift
@@ -47,6 +47,9 @@ public enum DeviceModel: CaseIterable {
     case iPhone16, iPhone16Plus
     case iPhone16Pro, iPhone16ProMax
     case iPhone16e
+    case iPhoneAir
+    case iPhone17
+    case iPhone17Pro, iPhone17ProMax
 
     case iPadFirstGen, iPadSecondGen, iPadThirdGen, iPadFourthGen, iPadFifthGen, iPadSixthGen, iPadSeventhGen, iPadEighthGen, iPadNinthGen, iPadTenthGen
     case iPadA16
@@ -193,6 +196,11 @@ extension DeviceModel {
         case (17, 4):           return .iPhone16Plus
             
         case (17, 5):           return .iPhone16e
+        
+        case (18, 1):           return .iPhone17Pro
+        case (18, 2):           return .iPhone17ProMax
+        case (18, 3):           return .iPhone17
+        case (18, 4):           return .iPhoneAir
         
         default:                return .unknown
         }
@@ -355,6 +363,8 @@ extension DeviceModel {
         case .iPhone15, .iPhone15Plus, .iPhone15Pro, .iPhone15ProMax:
             return true
         case .iPhone16, .iPhone16Plus, .iPhone16Pro, .iPhone16ProMax:
+            return true
+        case .iPhone17, .iPhoneAir, .iPhone17Pro, .iPhone17ProMax:
             return true
         default:
           return false

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -201,6 +201,15 @@ extension Identifier: CustomStringConvertible {
         
         case (17, 5):
             return "iPhone 16e"
+        
+        case (18, 3):
+            return "iPhone 17"
+        case (18, 4):
+            return "iPhone Air"
+        case (18, 1):
+            return "iPhone 17 Pro"
+        case (18, 2):
+            return "iPhone 17 Pro Max"
             
         default:
             return "unknown"

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -198,7 +198,9 @@ extension Identifier: CustomStringConvertible {
             return "iPhone 16 Pro"
         case (17, 2):
             return "iPhone 16 Pro Max"
-            
+        
+        case (17, 5):
+            return "iPhone 16e"
             
         default:
             return "unknown"

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -543,6 +543,24 @@ extension Identifier: CustomStringConvertible {
             return "Apple Watch Series 10, 42mm case (GPS + Cellular)"
         case (7, 11):
             return "Apple Watch Series 10, 46mm case (GPS + Cellular)"
+        case (7, 12):
+            return "Apple Watch Ultra 3"
+        case (7, 13):
+            return "Apple Watch SE 3, 40mm case (GPS)"
+        case (7, 14):
+            return "Apple Watch SE 3, 44mm case (GPS)"
+        case (7, 15):
+            return "Apple Watch SE 3, 40mm case (GPS + Cellular)"
+        case (7, 16):
+            return "Apple Watch SE 3, 44mm case (GPS + Cellular)"
+        case (7, 17):
+            return "Apple Watch Series 11, 42mm case (GPS)"
+        case (7, 18):
+            return "Apple Watch Series 11, 46mm case (GPS)"
+        case (7, 19):
+            return "Apple Watch Series 11, 42mm case (GPS + Cellular)"
+        case (7, 20):
+            return "Apple Watch Series 11, 46mm case (GPS + Cellular)"
         default:
             return "unknown"
         }

--- a/Sources/Identifier.swift
+++ b/Sources/Identifier.swift
@@ -419,6 +419,27 @@ extension Identifier: CustomStringConvertible {
         case (16, 6):
             return "iPad Pro M4 (13 inch, Wi-Fi+5G)"
             
+        case (16, 1):
+            return "iPad mini (A17 Pro, Wi-Fi)"
+        case (16, 2):
+            return "iPad mini (A17 Pro, Wi-Fi+5G)"
+            
+        case (15, 7):
+            return "iPad (A16, Wi-Fi)"
+        case (15, 8):
+            return "iPad (A16, Wi-Fi+5G)"
+            
+        case (15, 3):
+            return "iPad Air M3 (11 inch, Wi-Fi)"
+        case (15, 4):
+            return "iPad Air M3 (11 inch, Wi-Fi+5G)"
+        case (15, 6):
+            return "iPad Air M3 (13 inch, Wi-Fi)"
+        case (15, 7):
+            return "iPad Air M3 (13 inch, Wi-Fi+5G)"
+            
+
+            
         default:
             return "unknown"
         }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -128,19 +128,21 @@ extension Screen {
         case (1, 2), (2, 4), (2, 7), (3, 2), (3, 4):        return .medium(mm: 42)
             
         case (4, 1), (4, 3), (5, 1), (5, 3), (5, 9),
-             (5, 11), (6, 1), (6, 3), (6, 10), (6, 12):     return .small(mm: 40)
+             (5, 11), (6, 1), (6, 3), (6, 10), (6, 12),
+             (7, 13), (7, 15):                              return .small(mm: 40)
         case (4, 2), (4, 4), (5, 2), (5, 4), (5, 10),
-             (5, 12), (6, 2), (6, 4), (6, 11), (6, 13):     return .medium(mm: 44)
+             (5, 12), (6, 2), (6, 4), (6, 11), (6, 13),
+             (7, 14), (7, 16):                              return .medium(mm: 44)
             
         case (6, 6), (6, 8), (6, 14), (6, 16),
              (7, 1), (7, 3):                                return .small(mm: 41)
         case (6, 7), (6, 9), (6, 15), (6, 17),
              (7, 2), (7, 4):                                return .medium(mm: 45)
             
-        case (6, 18), (7, 5):                               return .ultra(mm: 49)
+        case (6, 18), (7, 5), (7, 12):                      return .ultra(mm: 49)
             
-        case (7, 8), (7, 10):                               return .small(mm: 42)
-        case (7, 9), (7, 11):                               return .medium(mm: 46)
+        case (7, 8), (7, 10), (7, 17), (7, 19):             return .small(mm: 42)
+        case (7, 9), (7, 11), (7, 18), (7, 20):             return .medium(mm: 46)
             
         default:                                            return nil
         }

--- a/Tests/DeviceModelTests.swift
+++ b/Tests/DeviceModelTests.swift
@@ -262,6 +262,11 @@ class DeviceModelTests: XCTestCase {
         XCTAssert(deviceModel == .iPhone16ProMax, "DeviceModel - .iPhone16ProMax is failing")
     }
     
+    func testDeviceModelIPhone16e() {
+        let deviceModel = DeviceModel(identifier: Identifier("iPhone17,5"))
+        XCTAssert(deviceModel == .iPhone16e, "DeviceModel - .iPhone16e is failing")
+    }
+    
     // MARK: - iPad Device Model tests
     
     func testDeviceModelIPadFirstGen() {
@@ -531,7 +536,8 @@ class DeviceModelTests: XCTestCase {
                                         .iPhone11, .iPhone11Pro, .iPhone11ProMax,
                                         .iPhone12, .iPhone12Pro, .iPhone12ProMax, .iPhone12mini,
                                         .iPhone13, .iPhone13mini, .iPhone13Pro, .iPhone13ProMax,
-                                        .iPhone14, .iPhone14Plus]
+                                        .iPhone14, .iPhone14Plus,
+                                        .iPhone16e]
 
         let noNotchModels: [DeviceModel] = DeviceModel.allCases.filter( { !notchModels.contains($0) })
 


### PR DESCRIPTION
Adds support for the following:

### iPhone
- iPhone 16e
- iPhone Air
- iPhone 17, Pro, Pro Max
### iPad
- iPad mini (A17 Pro)
- iPad (A16)
- iPad Air (M3)
### Watch
- Series 11
- Ultra 3
- SE 3

### Not completed yet:
- [ ] Tests
- [x] 2025 Devices